### PR TITLE
Terraform remote backend configuration

### DIFF
--- a/IaC/gke/README.md
+++ b/IaC/gke/README.md
@@ -13,7 +13,7 @@ This folder contains the GKE cluster definition files
 This file contains the backend definition. Currently uses a Hashicorp's remote backend. My Jenkins pipeline manages the .terraformrc for authentication purposes. You should adjust this to your environment
 
 ## vpcnetwork&#46;tf
-This file contains the google provider and the Virtual Private Cloud definitions.
+This file contains the google provider (including credentials definition) and the Virtual Private Cloud definitions.
 It has a `region` (the region where the VPC is deployed) output
 
 ## gke&#46;tf

--- a/IaC/gke/README.md
+++ b/IaC/gke/README.md
@@ -2,11 +2,15 @@
 This folder contains the GKE cluster definition files
 ```
 ├── README.md
+├── backend.tf
 ├── vpcnetwork.tf
 ├── gke.tf
 ├── gke.auto.tfvars 
 └── secrets.auto.tfvars.secret
 ```
+
+## backend&#46;tf
+This file contains the backend definition. Currently uses a Hashicorp's remote backend. My Jenkins pipeline manages the .terraformrc for authentication purposes. You should adjust this to your environment
 
 ## vpcnetwork&#46;tf
 This file contains the google provider and the Virtual Private Cloud definitions.

--- a/IaC/gke/backend.tf
+++ b/IaC/gke/backend.tf
@@ -1,0 +1,11 @@
+# Adjust the backend for your needs
+
+terraform {
+  backend "remote" {
+    organization = "muskeg"
+
+    workspaces {
+      name = "short-url"
+    }
+  }
+}

--- a/IaC/gke/gke.auto.tfvars
+++ b/IaC/gke/gke.auto.tfvars
@@ -2,4 +2,4 @@ region = "us-east1"
 primary_zone = "us-east1-b"
 gke_node_count = 1
 scaling_min = 1
-scaling_max =2 
+scaling_max = 3 

--- a/IaC/gke/vpcnetwork.tf
+++ b/IaC/gke/vpcnetwork.tf
@@ -7,6 +7,7 @@ variable "region" {
 }
 
 provider "google" {
+  credentials = file("service-account.json")
   project = var.project_id
   region  = var.region
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,9 +29,14 @@ pipeline {
                 }
             }
             environment {
+                // Credentials used by the pipeline
+                // GPG key for git-secret
                 GPG_SECRET_KEY = credentials('gpg-secret-key')
+                // GPC service account credentials
                 GOOGLE_APPLICATION_CREDENTIALS = credentials('short-url-service-account')
+                // The GCP project ID 
                 SHORT_URL_PROJECTID = credentials('short-url-projectID')
+                // The Terraform CLI config file
                 TERRAFORM_RC = credentials('terraform-cli-config')
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,16 +63,13 @@ pipeline {
                 GCP project ID. The same ID is used in secrets.auto.tfvars also revealed 
                 during the previous step.
                 */
-                sh """
-                /root/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-                /root/google-cloud-sdk/bin/gcloud config set project $SHORT_URL_PROJECTID
-                """
-
                 // Terraform + GKE
                 sh """
                 cp $TERRAFORM_RC ~/.terraformrc
                 cd $WORKSPACE/IaC/gke
                 terraform init
+                /root/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+                /root/google-cloud-sdk/bin/gcloud config set project $SHORT_URL_PROJECTID
                 terraform apply -auto-approve
                 """
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,13 +63,17 @@ pipeline {
                 GCP project ID. The same ID is used in secrets.auto.tfvars also revealed 
                 during the previous step.
                 */
+                // sh """
+                // /root/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+                // /root/google-cloud-sdk/bin/gcloud config set project $SHORT_URL_PROJECTID
+                // """
+
                 // Terraform + GKE
                 sh """
                 cp $TERRAFORM_RC ~/.terraformrc
                 cd $WORKSPACE/IaC/gke
+                cp $GOOGLE_APPLICATION_CREDENTIALS service-account.json
                 terraform init
-                /root/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-                /root/google-cloud-sdk/bin/gcloud config set project $SHORT_URL_PROJECTID
                 terraform apply -auto-approve
                 """
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
 
                 // Terraform + GKE
                 sh """
-                cp $TERRAFORM_RC ~/.terraformrc
+                cat $TERRAFORM_RC > ~/.terraformrc
                 source ~/.terraformrc
                 cd $WORKSPACE/IaC/gke
                 terraform init

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,7 @@ pipeline {
 
                 // Terraform + GKE
                 sh """
-                cat $TERRAFORM_RC > ~/.terraformrc
-                source ~/.terraformrc
+                cp $TERRAFORM_RC ~/.terraformrc
                 cd $WORKSPACE/IaC/gke
                 terraform init
                 terraform apply -auto-approve

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
                 GPG_SECRET_KEY = credentials('gpg-secret-key')
                 GOOGLE_APPLICATION_CREDENTIALS = credentials('short-url-service-account')
                 SHORT_URL_PROJECTID = credentials('short-url-projectID')
+                TERRAFORM_RC = credentials('terraform-cli-config')
             }
             steps {
 
@@ -64,6 +65,8 @@ pipeline {
 
                 // Terraform + GKE
                 sh """
+                cp $TERRAFORM_RC ~/.terraformrc
+                source ~/.terraformrc
                 cd $WORKSPACE/IaC/gke
                 terraform init
                 terraform apply -auto-approve


### PR DESCRIPTION
Adding a definition for a remote backend to ensure Terraform state persistence. Setting up handling of credentials for terraform.io and GCP